### PR TITLE
Parameterize split_type in tester

### DIFF
--- a/Dockerfile.tester
+++ b/Dockerfile.tester
@@ -37,7 +37,7 @@ ADD ibpc_tester /opt/ros/overlay/src/ibpc_tester
 RUN . /opt/ros/jazzy/setup.sh \
     && . /opt/ros/underlay/install/setup.sh \
     && cd /opt/ros/overlay \
-    && cd src/ && git clone https://github.com/Yadunund/bop_toolkit.git -b add_ipd_dataset src/ && cd ../ \
+    && cd src/ && git clone https://github.com/Yadunund/bop_toolkit.git -b yadu/add_val_key src/ && cd ../ \
     # && rosdep install --from-paths src --ignore-src --rosdistro jazzy -yir \
     && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
     --event-handlers=console_direct+ \
@@ -49,6 +49,7 @@ FROM base
 ARG DATASET_NAME
 ARG SERVICE_PACKAGE=ibpc_tester
 ARG SERVICE_EXECUTABLE_NAME=ibpc_tester
+ARG SPLIT_TYPE
 
 RUN apt update \
     && sudo apt install curl -y \
@@ -72,6 +73,7 @@ RUN sed --in-place \
 ENV DATASET_NAME=${DATASET_NAME}
 ENV SERVICE_PACKAGE=${SERVICE_PACKAGE}
 ENV SERVICE_EXECUTABLE_NAME=${SERVICE_EXECUTABLE_NAME}
+ENV SPLIT_TYPE=${SPLIT_TYPE}
 
 CMD exec /opt/ros/overlay/install/lib/${SERVICE_PACKAGE}/${SERVICE_EXECUTABLE_NAME} \
-    --ros-args -p dataset_name:=${DATASET_NAME}
+    --ros-args -p dataset_name:=${DATASET_NAME} -p split_type:=${SPLIT_TYPE}

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ For more details on the challenge, [click here](https://bpc.opencv.org/).
 
 This repository contains the ROS interfaces, sample submission code and evaluation service for the Perception Challenge For Bin-Picking.
 
-- **Estimator:**  
+- **Estimator:**
   The estimator code represents the sample submission. Participants need to implement their solution by editing the placeholder code in the function `get_pose_estimates` in `ibpc_pose_estimator.py` (or its C++ counterpart). The tester will invoke the participant's solution via a ROS 2 service call over the `/get_pose_estimates` endpoint.
 
-- **Tester:**  
+- **Tester:**
   The tester code serves as the evaluation service. A copy of this code will be running on the evaluation server and is provided for reference only. It loads the test dataset, prepares image inputs, invokes the estimator service repeatedly, collects the results, and submits for further evaluation.
 
-- **ROS Interface:**  
+- **ROS Interface:**
   The API for the challenge is a ROS service, [GetPoseEstimates](ibpc_interfaces/srv/GetPoseEstimates.srv), over `/get_pose_estimates`. Participants implement the service callback on a dedicated ROS node (commonly referred to as the PoseEstimatorNode) which processes the input data (images and metadata) and returns pose estimation results.
 
 In addition, we provide the [ibpc_py tool](https://github.com/Yadunund/bpc/tree/main/ibpc_py) which facilitates downloading the challenge data and performing various related tasks. Please refer to its README for further details.
@@ -26,13 +26,13 @@ In addition, we provide the [ibpc_py tool](https://github.com/Yadunund/bpc/tree/
 
 The core architecture of the challenge is based on ROS 2. Participants are required to respond to a ROS 2 Service request with pose estimation results. The key elements of the architecture are:
 
-- **Service API:**  
-  The ROS service interface (defined in the [GetPoseEstimates](ibpc_interfaces/srv/GetPoseEstimates.srv) file) acts as the API for the challenge. 
+- **Service API:**
+  The ROS service interface (defined in the [GetPoseEstimates](ibpc_interfaces/srv/GetPoseEstimates.srv) file) acts as the API for the challenge.
 
-- **PoseEstimatorNode:**  
+- **PoseEstimatorNode:**
   Participants are provided with C++ and Python templates for the PoseEstimatorNode. Your task is to implement the callback function (e.g., `get_pose_estimates`) that performs the required computation. Since the API is simply a ROS endpoint, you can use any of the available [ROS 2 client libraries](https://docs.ros.org/en/jazzy/Concepts/Basic/About-Client-Libraries.html#client-libraries) including C++, Python, Rust, Node.js, or C#. Please use [ROS 2 Jazzy Jalisco](https://docs.ros.org/en/jazzy/index.html).
 
-- **TesterNode:**  
+- **TesterNode:**
   A fully implemented TesterNode is provided that:
   - Uses the bop_toolkit_lib to load the test dataset and prepare image inputs.
   - Repeatedly calls the PoseEstimatorNode service over the `/get_pose_estimates` endpoint.
@@ -103,7 +103,7 @@ rocker --nvidia --cuda run --network=host ibpc:pose_estimator
 > Note: Substitute the <PATH_TO_DATASET> with the location of the IPD dataset you've downloaded.
 
 ```bash
-docker run --network=host -e BOP_PATH=/opt/ros/underlay/install/datasets -v<PATH_TO_DATASET>:/opt/ros/underlay/install/datasets -it ibpc:tester 
+docker run --network=host -e BOP_PATH=/opt/ros/underlay/install/datasets -e SPLIT_TYPE=val -v<PATH_TO_DATASET>:/opt/ros/underlay/install/datasets -it ibpc:tester
 ```
 
 ## Next Steps

--- a/ibpc_tester/ibpc_tester/ibpc_tester.py
+++ b/ibpc_tester/ibpc_tester/ibpc_tester.py
@@ -147,9 +147,15 @@ def main(argv=sys.argv):
     node.get_logger().info(f"Datasets path is set to {datasets_path}.")
 
     # Declare parameters.
-    dataset_name = node.declare_parameter("dataset_name", "ipd").get_parameter_value().string_value
-    split_type = node.declare_parameter("split_type", "val").get_parameter_value().string_value
-    node.get_logger().info(f"Loading from dataset {dataset_name} with split_type {split_type}.")
+    dataset_name = (
+        node.declare_parameter("dataset_name", "ipd").get_parameter_value().string_value
+    )
+    split_type = (
+        node.declare_parameter("split_type", "val").get_parameter_value().string_value
+    )
+    node.get_logger().info(
+        f"Loading from dataset {dataset_name} with split_type {split_type}."
+    )
 
     debug_cam_1 = None
     debug_cam_2 = None

--- a/ibpc_tester/ibpc_tester/ibpc_tester.py
+++ b/ibpc_tester/ibpc_tester/ibpc_tester.py
@@ -147,9 +147,9 @@ def main(argv=sys.argv):
     node.get_logger().info(f"Datasets path is set to {datasets_path}.")
 
     # Declare parameters.
-    node.declare_parameter("dataset_name", "ipd")
-    dataset_name = node.get_parameter("dataset_name").get_parameter_value().string_value
-    node.get_logger().info("Loading from dataset {dataset_name}.")
+    dataset_name = node.declare_parameter("dataset_name", "ipd").get_parameter_value().string_value
+    split_type = node.declare_parameter("split_type", "val").get_parameter_value().string_value
+    node.get_logger().info(f"Loading from dataset {dataset_name} with split_type {split_type}.")
 
     debug_cam_1 = None
     debug_cam_2 = None
@@ -165,7 +165,7 @@ def main(argv=sys.argv):
         debug_photoneo = DebugPublishers("photoneo", node)
 
     # Load the test split.
-    test_split = get_split_params(datasets_path, dataset_name, "test")
+    test_split = get_split_params(datasets_path, dataset_name, split_type)
     node.get_logger().info(f"Parsed test split: {test_split}")
 
     # Create the ROS client to query pose estimates.


### PR DESCRIPTION
The `split_type` can be set via ROS arg `split_type`.  Also switch to https://github.com/thodan/bop_toolkit/pull/176.