### PR TITLE
Save results to csv file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,4 +38,4 @@ jobs:
           file: Dockerfile.tester
           load: true
           push: true
-          tags: ghcr.io/yadunund/bpc/estimator-tester:latest
+          tags: ghcr.io/opencv/bpc/estimator-tester:latest

--- a/Dockerfile.estimator
+++ b/Dockerfile.estimator
@@ -37,12 +37,6 @@ FROM underlay AS overlay
 ARG SERVICE_PACKAGE=ibpc_pose_estimator_py
 ARG SERVICE_EXECUTABLE_NAME=ibpc_pose_estimator
 
-# TODO(Yadunund): Remove this step after next Jazzy sync.
-RUN apt update \
-    && sudo apt install curl -y \
-    && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
 RUN apt-get update \
     &&  apt install -y ros-jazzy-rmw-zenoh-cpp \
     && rm -rf /var/lib/apt/lists/*
@@ -85,4 +79,3 @@ ENV MODEL_DIR=/opt/ros/underlay/install/models
 
 CMD exec /opt/ros/overlay/install/lib/${SERVICE_PACKAGE}/${SERVICE_EXECUTABLE_NAME} \
     --ros-args -p model_dir:=${MODEL_DIR}
-    

--- a/Dockerfile.tester
+++ b/Dockerfile.tester
@@ -22,12 +22,6 @@ RUN . /opt/ros/jazzy/setup.sh \
 
 FROM underlay AS overlay
 
-# TODO(Yadunund): Remove this step after next Jazzy sync.
-RUN apt update \
-    && sudo apt install curl -y \
-    && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
 RUN apt-get update \
     &&  apt install -y ros-jazzy-rmw-zenoh-cpp \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.tester
+++ b/Dockerfile.tester
@@ -42,6 +42,8 @@ RUN . /opt/ros/jazzy/setup.sh \
 FROM base
 
 ARG DATASET_NAME
+ARG OUTPUT_DIR=/submission
+ARG OUTPUT_FILENAME=submission.csv
 ARG SERVICE_PACKAGE=ibpc_tester
 ARG SERVICE_EXECUTABLE_NAME=ibpc_tester
 ARG SPLIT_TYPE=val
@@ -52,7 +54,7 @@ RUN apt update \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 RUN apt-get update \
-    &&  apt install -y ros-jazzy-rmw-zenoh-cpp python3-imageio python3-png python3-pip python3-scipy \
+    &&  apt install -y ros-jazzy-rmw-zenoh-cpp python3-imageio python3-pandas python3-png python3-pip python3-scipy \
     && rm -rf /var/lib/apt/lists/*
 
 # TODO remove deprecated pytz usage
@@ -66,9 +68,11 @@ RUN sed --in-place \
     /ros_entrypoint.sh
 
 ENV DATASET_NAME=${DATASET_NAME}
+ENV OUTPUT_DIR=${OUTPUT_DIR}
+ENV OUTPUT_FILENAME=${OUTPUT_FILENAME}
 ENV SERVICE_PACKAGE=${SERVICE_PACKAGE}
 ENV SERVICE_EXECUTABLE_NAME=${SERVICE_EXECUTABLE_NAME}
 ENV SPLIT_TYPE=${SPLIT_TYPE}
 
 CMD exec /opt/ros/overlay/install/lib/${SERVICE_PACKAGE}/${SERVICE_EXECUTABLE_NAME} \
-    --ros-args -p dataset_name:=${DATASET_NAME} -p split_type:=${SPLIT_TYPE}
+    --ros-args -p dataset_name:=${DATASET_NAME} -p split_type:=${SPLIT_TYPE} -p output_dir:=${OUTPUT_DIR} -p output_filename:=${OUTPUT_FILENAME}

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker buildx build -t ibpc:tester \
 ### Start the Zenoh router
 
 ```bash
-docker run --init --rm --net host eclipse/zenoh:1.1.1 --no-multicast-scouting
+docker run --init --rm --net host eclipse/zenoh:1.2.1 --no-multicast-scouting
 ```
 
 ### Run the pose estimator
@@ -102,10 +102,10 @@ rocker --nvidia --cuda run --network=host ibpc:pose_estimator
 
 ### Run the tester
 
-> Note: Substitute the <PATH_TO_DATASET> with the directory that contains the [ipd](https://huggingface.co/datasets/bop-benchmark/ipd/tree/main) dataset.
+> Note: Substitute the <PATH_TO_DATASET> with the directory that contains the [ipd](https://huggingface.co/datasets/bop-benchmark/ipd/tree/main) dataset. Similarly, substitute <PATH_TO_OUTPUT_DIR> with the directory that should contain the results from the pose estimator. By default, the results will be saved as a `submission.csv` file but this filename can be updated by setting the `OUTPUT_FILENAME` environment variable.
 
 ```bash
-docker run --network=host -e BOP_PATH=/opt/ros/underlay/install/datasets -e SPLIT_TYPE=val -v<PATH_TO_DATASET>:/opt/ros/underlay/install/datasets -it ibpc:tester
+docker run --network=host -e BOP_PATH=/opt/ros/underlay/install/datasets -e SPLIT_TYPE=val -v<PATH_TO_DATASET>:/opt/ros/underlay/install/datasets -v<PATH_TO_OUTPUT_DIR>:/submission -it ibpc:tester
 ```
 
 ## Baseline Solution

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Perception Challenge For Bin-Picking
 
-[![build](https://github.com/Yadunund/bpc/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/Yadunund/bpc/actions/workflows/build.yaml)
-[![style](https://github.com/Yadunund/bpc/actions/workflows/style.yaml/badge.svg?branch=main)](https://github.com/Yadunund/bpc/actions/workflows/style.yaml)
+[![build](https://github.com/opencv/bpc/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/opencv/bpc/actions/workflows/build.yaml)
+[![style](https://github.com/opencv/bpc/actions/workflows/style.yaml/badge.svg?branch=main)](https://github.com/opencv/bpc/actions/workflows/style.yaml)
 
 For more details on the challenge, [click here](https://bpc.opencv.org/).
 
@@ -20,7 +20,7 @@ This repository contains the ROS interfaces, sample submission code and evaluati
 - **ROS Interface:**
   The API for the challenge is a ROS service, [GetPoseEstimates](ibpc_interfaces/srv/GetPoseEstimates.srv), over `/get_pose_estimates`. Participants implement the service callback on a dedicated ROS node (commonly referred to as the PoseEstimatorNode) which processes the input data (images and metadata) and returns pose estimation results.
 
-In addition, we provide the [ibpc_py tool](https://github.com/Yadunund/bpc/tree/main/ibpc_py) which facilitates downloading the challenge data and performing various related tasks. Please refer to its README for further details.
+In addition, we provide the [ibpc_py tool](https://github.com/opencv/bpc/tree/main/ibpc_py) which facilitates downloading the challenge data and performing various related tasks. Please refer to its README for further details.
 
 ## Design
 
@@ -62,7 +62,7 @@ Participants are expected to modify the estimator code to implement their soluti
 ```bash
 mkdir -p ~/ws_bpc/src
 cd ~/ws_bpc/src
-git clone https://github.com/Yadunund/bpc.git
+git clone https://github.com/opencv/bpc.git
 ```
 
 ## Build
@@ -110,7 +110,7 @@ docker run --network=host -e BOP_PATH=/opt/ros/underlay/install/datasets -e SPLI
 
 ## Baseline Solution
 
-We provide a simple baseline solution as a reference for implementing the solution in `ibpc_pose_estimator_py`. Please refer to the [baseline_solution](https://github.com/Yadunund/bpc/tree/baseline_solution) branch and follow the instructions there.
+We provide a simple baseline solution as a reference for implementing the solution in `ibpc_pose_estimator_py`. Please refer to the [baseline_solution](https://github.com/opencv/bpc/tree/baseline_solution) branch and follow the instructions there.
 
 ## Next Steps
 

--- a/ibpc_py/src/ibpc/ibpc.py
+++ b/ibpc_py/src/ibpc/ibpc.py
@@ -166,7 +166,6 @@ def main():
         print("Fetch complete")
         return
 
-
     tester_args = {
         "network": "host",
         "extension_blacklist": {},
@@ -177,9 +176,10 @@ def main():
         ],
         "console_output_file": "ibpc_test_output.log",
         "volume": [
-            [f"{args_dict['dataset_directory']}:/opt/ros/underlay/install/datasets",
-             f"{args_dict['result_directory']}:/submission",
-             ]
+            [
+                f"{args_dict['dataset_directory']}:/opt/ros/underlay/install/datasets",
+                f"{args_dict['result_directory']}:/submission",
+            ]
         ],
     }
     print("Buiding tester env")
@@ -223,14 +223,13 @@ def main():
     tester_thread.start()
 
     args_dict["network"] = "host"
-    args_dict["extension_blacklist"] = {},
+    args_dict["extension_blacklist"] = ({},)
 
     # Confirm dataset directory is absolute
     args_dict["dataset_directory"] = os.path.abspath(args_dict["dataset_directory"])
 
     active_extensions = extension_manager.get_active_extensions(args_dict)
     print("Active extensions %s" % [e.get_name() for e in active_extensions])
-
 
     dig = DockerImageGenerator(
         active_extensions, args_dict, args_dict["estimator_image"]

--- a/ibpc_py/src/ibpc/ibpc.py
+++ b/ibpc_py/src/ibpc/ibpc.py
@@ -204,7 +204,7 @@ def main():
 
     print("Buiding zenoh env")
     dig_zenoh = DockerImageGenerator(
-        zenoh_extensions, zenoh_args, "eclipse/zenoh:1.1.1"
+        zenoh_extensions, zenoh_args, "eclipse/zenoh:1.2.1"
     )
     exit_code = dig_zenoh.build(**zenoh_args)
     if exit_code != 0:

--- a/ibpc_py/src/ibpc/ibpc.py
+++ b/ibpc_py/src/ibpc/ibpc.py
@@ -144,7 +144,7 @@ def main():
     test_parser.add_argument("--dataset_directory", action="store", default=".")
     test_parser.add_argument("--debug-inside", action="store_true")
     test_parser.add_argument(
-        "--tester-image", default="ghcr.io/yadunund/bpc/estimator-tester:latest"
+        "--tester-image", default="ghcr.io/opencv/bpc/estimator-tester:latest"
     )
 
     fetch_parser = sub_parsers.add_parser("fetch")

--- a/ibpc_tester/ibpc_tester/ibpc_tester.py
+++ b/ibpc_tester/ibpc_tester/ibpc_tester.py
@@ -175,6 +175,22 @@ def main(argv=sys.argv):
     node.get_logger().info(
         f"Loading from dataset {dataset_name} with split_type {split_type}."
     )
+    output_dir = Path(
+        node.declare_parameter("output_dir", "/submission")
+        .get_parameter_value()
+        .string_value
+    )
+    output_filename = (
+        node.declare_parameter("output_filename", "submission.csv")
+        .get_parameter_value()
+        .string_value
+    )
+    try:
+        output_filepath = (output_dir / output_filename).resolve()
+    except Exception as e:
+        print(f"Error creating filepath: {e}")
+        output_filepath = filename
+    node.get_logger().info(f"Submission results will be written to {output_filepath}.")
 
     debug_cam_1 = None
     debug_cam_2 = None
@@ -257,8 +273,8 @@ def main(argv=sys.argv):
 
     # Convert results to DataFrame and save
     df = pd.DataFrame(results)
-    df.to_csv("submission.csv", index=False)
-    node.get_logger().info("Results saved to submission.csv")
+    df.to_csv(output_filepath, index=False)
+    node.get_logger().info(f"Results saved to {output_filepath}")
 
     node.destroy_node()
     rclpy.try_shutdown()

--- a/ibpc_tester/ibpc_tester/ibpc_tester.py
+++ b/ibpc_tester/ibpc_tester/ibpc_tester.py
@@ -141,17 +141,19 @@ class BOPCamera:
 
 def pose_msg_to_rt(pose_msg):
     # Convert quaternion to rotation matrix
-    r = Rotation.from_quat([
-        pose_msg.orientation.x,
-        pose_msg.orientation.y,
-        pose_msg.orientation.z,
-        pose_msg.orientation.w
-    ])
+    r = Rotation.from_quat(
+        [
+            pose_msg.orientation.x,
+            pose_msg.orientation.y,
+            pose_msg.orientation.z,
+            pose_msg.orientation.w,
+        ]
+    )
     R = r.as_matrix().flatten().tolist()
-    
+
     # Get translation
     t = [pose_msg.position.x, pose_msg.position.y, pose_msg.position.z]
-    
+
     return R, t
 
 
@@ -231,21 +233,23 @@ def main(argv=sys.argv):
             )
             future = client.call_async(request)
             rclpy.spin_until_future_complete(node, future)
-            
+
             if future.result() is not None:
                 node.get_logger().info(f"Got results: {future.result().pose_estimates}")
                 # Process results and add to results list
                 for pose_estimate in future.result().pose_estimates:
                     R, t = pose_msg_to_rt(pose_estimate.pose)
-                    results.append({
-                        'scene_id': scene_id,
-                        'im_id': img_id,
-                        'obj_id': pose_estimate.obj_id,
-                        'score': pose_estimate.score,
-                        'R': R,
-                        't': t,
-                        'time': -1
-                    })
+                    results.append(
+                        {
+                            "scene_id": scene_id,
+                            "im_id": img_id,
+                            "obj_id": pose_estimate.obj_id,
+                            "score": pose_estimate.score,
+                            "R": R,
+                            "t": t,
+                            "time": -1,
+                        }
+                    )
             else:
                 node.get_logger().error(
                     "Exception while calling service: %r" % future.exception()
@@ -253,7 +257,7 @@ def main(argv=sys.argv):
 
     # Convert results to DataFrame and save
     df = pd.DataFrame(results)
-    df.to_csv('submission.csv', index=False)
+    df.to_csv("submission.csv", index=False)
     node.get_logger().info("Results saved to submission.csv")
 
     node.destroy_node()

--- a/ibpc_tester/ibpc_tester/ibpc_tester.py
+++ b/ibpc_tester/ibpc_tester/ibpc_tester.py
@@ -5,6 +5,7 @@ from cv_bridge import CvBridge
 import numpy as np
 from pathlib import Path
 import sys
+import pandas as pd
 
 import rclpy
 from rclpy.node import Node
@@ -138,6 +139,22 @@ class BOPCamera:
         self.t = self.camera_params["cam_t_w2c"]
 
 
+def pose_msg_to_rt(pose_msg):
+    # Convert quaternion to rotation matrix
+    r = Rotation.from_quat([
+        pose_msg.orientation.x,
+        pose_msg.orientation.y,
+        pose_msg.orientation.z,
+        pose_msg.orientation.w
+    ])
+    R = r.as_matrix().flatten().tolist()
+    
+    # Get translation
+    t = [pose_msg.position.x, pose_msg.position.y, pose_msg.position.z]
+    
+    return R, t
+
+
 def main(argv=sys.argv):
     rclpy.init(args=argv)
     args_without_ros = rclpy.utilities.remove_ros_args(argv)
@@ -180,7 +197,10 @@ def main(argv=sys.argv):
         node.get_logger().info(
             "/get_pose_estimates service not available, waiting again..."
         )
-    results = {}
+
+    # Create list to store results
+    results = []
+
     # Get pose estimates for every image in every scene.
     for scene_id in test_split["scene_ids"]:
         scene_dir = Path(test_split["split_path"]) / "{scene_id:06d}".format(
@@ -211,14 +231,30 @@ def main(argv=sys.argv):
             )
             future = client.call_async(request)
             rclpy.spin_until_future_complete(node, future)
+            
             if future.result() is not None:
                 node.get_logger().info(f"Got results: {future.result().pose_estimates}")
+                # Process results and add to results list
+                for pose_estimate in future.result().pose_estimates:
+                    R, t = pose_msg_to_rt(pose_estimate.pose)
+                    results.append({
+                        'scene_id': scene_id,
+                        'im_id': img_id,
+                        'obj_id': pose_estimate.obj_id,
+                        'score': pose_estimate.score,
+                        'R': R,
+                        't': t,
+                        'time': -1
+                    })
             else:
                 node.get_logger().error(
                     "Exception while calling service: %r" % future.exception()
                 )
-        # todo(Yadunund): Remove break after dataset is fixed.
-        break
+
+    # Convert results to DataFrame and save
+    df = pd.DataFrame(results)
+    df.to_csv('submission.csv', index=False)
+    node.get_logger().info("Results saved to submission.csv")
 
     node.destroy_node()
     rclpy.try_shutdown()

--- a/ibpc_tester/ibpc_tester/ibpc_tester.py
+++ b/ibpc_tester/ibpc_tester/ibpc_tester.py
@@ -189,7 +189,7 @@ def main(argv=sys.argv):
         output_filepath = (output_dir / output_filename).resolve()
     except Exception as e:
         print(f"Error creating filepath: {e}")
-        output_filepath = filename
+        output_filepath = output_filename
     node.get_logger().info(f"Submission results will be written to {output_filepath}.")
 
     debug_cam_1 = None

--- a/ibpc_tester/package.xml
+++ b/ibpc_tester/package.xml
@@ -11,6 +11,7 @@
   <exec_depend>ibpc_interfaces</exec_depend>
 
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>python3-pandas</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This PR updates the `tester` to compile results into a csv file in a format similar to what was expected in previous [bop challenges](https://bop.felk.cvut.cz/challenges/bop-challenge-2019/#formatofresults). The only difference being instead of separating matrix elements by spaces, we use commas.

This file is further written to disk to directory / filename that can be configured. By default it writes to `/submission/submission.cvs`. README is updated to mount another volume for this output directory so that the results can be accessed outside of the container.

Lastly, I took the liberty to bump the zenoh router to `1.2.1.` to match the zenoh version in the latest jazzy binaries that were [released today](https://discourse.ros.org/t/new-packages-for-jazzy-jalisco-2025-02-10/41950)