### PR TITLE
Simplify the argument passing

### DIFF
--- a/Dockerfile.tester
+++ b/Dockerfile.tester
@@ -41,13 +41,6 @@ RUN . /opt/ros/jazzy/setup.sh \
 # result stage: base + copied install folders from the overlay + service setup.
 FROM base
 
-ARG DATASET_NAME
-ARG OUTPUT_DIR=/submission
-ARG OUTPUT_FILENAME=submission.csv
-ARG SERVICE_PACKAGE=ibpc_tester
-ARG SERVICE_EXECUTABLE_NAME=ibpc_tester
-ARG SPLIT_TYPE=val
-
 RUN apt update \
     && sudo apt install curl -y \
     && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
@@ -67,12 +60,13 @@ RUN sed --in-place \
     --expression '$isource "/opt/ros/overlay/install/setup.bash"' \
     /ros_entrypoint.sh
 
-ENV DATASET_NAME=${DATASET_NAME}
-ENV OUTPUT_DIR=${OUTPUT_DIR}
-ENV OUTPUT_FILENAME=${OUTPUT_FILENAME}
-ENV SERVICE_PACKAGE=${SERVICE_PACKAGE}
-ENV SERVICE_EXECUTABLE_NAME=${SERVICE_EXECUTABLE_NAME}
-ENV SPLIT_TYPE=${SPLIT_TYPE}
+
+ENV DATASET_NAME=ipd
+ENV OUTPUT_DIR=/submission
+ENV OUTPUT_FILENAME=submission.csv
+ENV SERVICE_PACKAGE=ibpc_tester
+ENV SERVICE_EXECUTABLE_NAME=ibpc_tester
+ENV SPLIT_TYPE=val
 
 CMD exec /opt/ros/overlay/install/lib/${SERVICE_PACKAGE}/${SERVICE_EXECUTABLE_NAME} \
     --ros-args -p dataset_name:=${DATASET_NAME} -p split_type:=${SPLIT_TYPE} -p output_dir:=${OUTPUT_DIR} -p output_filename:=${OUTPUT_FILENAME}

--- a/ibpc_py/src/ibpc/ibpc.py
+++ b/ibpc_py/src/ibpc/ibpc.py
@@ -171,8 +171,8 @@ def main():
         "extension_blacklist": {},
         "operating_mode": OPERATIONS_NON_INTERACTIVE,
         "env": [
-            [f"BOP_PATH:/opt/ros/underlay/install/datasets/{args_dict['dataset']}"],
-            [f"DATASET_NAME:{args_dict['dataset']}"],
+            [f"BOP_PATH=/opt/ros/underlay/install/datasets/{args_dict['dataset']}"],
+            [f"DATASET_NAME={args_dict['dataset']}"],
         ],
         "console_output_file": "ibpc_test_output.log",
         "volume": [


### PR DESCRIPTION
We definitely had a lot of extra boilerplate in there. Taking that out and validating that it works with bpc command. 

If we can converge on the bpc command we can simplify the process of generating the cmd and the complexity can go away from the Dockerfile itself. 

Following up from threads in https://github.com/opencv/bpc/pull/33#discussion_r1950423619