### PR TITLE
Update readme to use ibpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,72 @@ Participants are expected to modify the estimator code to implement their soluti
 ## Requirements
 
 - [Docker](https://docs.docker.com/)
-- [rocker](https://github.com/osrf/rocker)
+ * Docker installed with their user in docker group for passwordless invocations.
+- 7z -- `apt install 7zip`
+- Python3 with virtualenv  -- `apt install python3-virtualenv`
 
 > Note: Participants are expected to submit Docker containers, so all development workflows are designed with this in mind.
 
 ## Setup
 
+1. Setup a workspace
+```
+mkdir -p ~/bpc_ws
+```
+
+1. Create a virtual environment 
+
+
+```
+python3 -m venv ~/bpc_ws/bpc_env
+```
+
+1. Activate that virtual env
+
+```
+source ~/bpc_ws/bpc_env/bin/activate
+```
+
+**For any new shell interacting with the `bpc` command you will have to rerun this source command.**
+
+1. Install bpc 
+```
+pip install ibpc
+```
+
+
+
+## Fetch the dataset
+
+```
+cd ~/bpc_ws
+bpc fetch ipd
+```
+
+## Run the test
+
+**At the moment the published tester is not available. You will have to build it locally see below in Development to build `ibpc:tester` and pass --tester-image `ibpc:tester`
+
+```
+bpc test  ipd
+```
+
+The console output will show the system getting started and then the output of the estimator. 
+
+If you would like to interact with the estimator and run alternative commands or anything else in the container you can invoke it with `--debug`
+
+The tester console output will be streamed to the file `ibpc_test_output.log` Use this to see it
+
+```
+tail -f ibpc_test_output.log
+```
+
+The results will come out as `submission.csv` when the tester is complete.
+
+
+## Development
+
+### Fetch the source repository
 
 ```bash
 mkdir -p ~/ws_bpc/src
@@ -65,9 +125,10 @@ cd ~/ws_bpc/src
 git clone https://github.com/opencv/bpc.git
 ```
 
-## Build
 
 ### Build the ibpc_pose_estimator
+
+We will use the following example pose estimator for the demo. 
 
 ```bash
 cd ~/ws_bpc/src/bpc
@@ -76,6 +137,8 @@ docker buildx build -t ibpc:pose_estimator \
     --build-arg="MODEL_DIR=models" \
     .
 ```
+
+If you want to reproduce the tester image run the following command
 
 ### Build the ibpc_tester
 
@@ -86,7 +149,19 @@ docker buildx build -t ibpc:tester \
     .
 ```
 
-## Run
+And then when you invoke `bpc test` append the argument `--tester-image ibpc:tester` to use your local build.
+
+### If you would like the training data
+
+Use the command
+```
+bpc fetch ipd_all
+```
+
+
+### Manually Run components 
+
+
 
 ### Start the Zenoh router
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ mkdir -p ~/bpc_ws
 
 1. Create a virtual environment 
 
+📄 If you're already working in some form of virtualenv you can continue to use that and install `bpc` in that instead of making a new one. 
 
 ```
 python3 -m venv ~/bpc_ws/bpc_env
@@ -100,10 +101,12 @@ bpc fetch ipd
 
 ### Run the test
 
-The test will validate your provide image against the test dataset.
+The test will validate your provided image against the test dataset.
 When you build a new image you rerun this test.
 
-**At the moment the published tester is not available. You will have to build it locally see below in Development to build `ibpc:tester` and pass `--tester-image ibpc:tester` as additional arguments. THe default is `ghcr.io/opencv/bpc/estimator-tester:latest` but that's currently unavailable.
+**At the moment the published tester is not available.
+You will have to build it locally see below in Development to build `ibpc:tester` and pass `--tester-image ibpc:tester` as additional arguments.
+The default is `ghcr.io/opencv/bpc/estimator-tester:latest` but that's currently unavailable.
 
 ```
 bpc test <POSE_ESTIMATOR_DOCKER_TAG> ipd

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ Participants are expected to modify the estimator code to implement their soluti
 
 This section will guide you through validating your image.
 
-1. Setup a workspace
+#### Setup a workspace
 ```
 mkdir -p ~/bpc_ws
 ```
 
-1. Create a virtual environment 
+#### Create a virtual environment 
 
 📄 If you're already working in some form of virtualenv you can continue to use that and install `bpc` in that instead of making a new one. 
 
@@ -77,7 +77,7 @@ mkdir -p ~/bpc_ws
 python3 -m venv ~/bpc_ws/bpc_env
 ```
 
-1. Activate that virtual env
+#### Activate that virtual env
 
 ```
 source ~/bpc_ws/bpc_env/bin/activate
@@ -85,7 +85,7 @@ source ~/bpc_ws/bpc_env/bin/activate
 
 **For any new shell interacting with the `bpc` command you will have to rerun this source command.**
 
-1. Install bpc 
+#### Install bpc 
 ```
 pip install ibpc
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ To simplify the evaluation process, Dockerfiles are provided to generate contain
 
 Participants are expected to modify the estimator code to implement their solution. Once completed, your custom estimator should be containerized using Docker and submitted according to the challenge requirements. More detailed submission instructions will be provided soon.
 
-## Requirements
+
+## Validation Setup
+
+### Requirements
 
 - [Docker](https://docs.docker.com/)
  * Docker installed with their user in docker group for passwordless invocations.
@@ -58,7 +61,8 @@ Participants are expected to modify the estimator code to implement their soluti
 
 > Note: Participants are expected to submit Docker containers, so all development workflows are designed with this in mind.
 
-## Setup
+
+This section will guide you through validating your image.
 
 1. Setup a workspace
 ```
@@ -87,14 +91,14 @@ pip install ibpc
 
 
 
-## Fetch the dataset
+### Fetch the dataset
 
 ```
 cd ~/bpc_ws
 bpc fetch ipd
 ```
 
-## Run the test
+### Run the test
 
 The test will validate your provide image against the test dataset.
 When you build a new image you rerun this test.
@@ -126,7 +130,10 @@ tail -f ibpc_test_output.log
 The results will come out as `submission.csv` when the tester is complete.
 
 
-## Development
+## Pose Estimator Development
+
+Above you've learned how to validate a system. 
+It's time to learn how to create your own Pose Estimator.
 
 ### Fetch the source repository
 
@@ -135,7 +142,6 @@ mkdir -p ~/ws_bpc/src
 cd ~/ws_bpc/src
 git clone https://github.com/opencv/bpc.git
 ```
-ibpc:pose_estimator
 
 ### Build the ibpc_pose_estimator
 
@@ -143,28 +149,50 @@ We will use the following example pose estimator for the demo.
 
 ```bash
 cd ~/ws_bpc/src/bpc
-docker buildx build -t ibpc:pose_estimator \
+docker buildx build -t bpc_pose_estimator:example \
     --file ./Dockerfile.estimator \
     --build-arg="MODEL_DIR=models" \
     .
 ```
 
-If you want to reproduce the tester image run the following command
+If you use this tag the `bpc` invocation will be as follows where you use the image you just built:
+
+`bpc test bpc_pose_estimator:example ipd`
+
+
+👷 At this point it is up to you to fork and fill in the implementation of the pose estimator. 👷
+
+
+### Baseline Solution
+
+We provide a simple baseline solution as a reference for implementing the solution in `ibpc_pose_estimator_py`. Please refer to the [baseline_solution](https://github.com/opencv/bpc/tree/baseline_solution) branch and follow the instructions there.
+
+
+## Further Details
+
+The above is enough to get you going.
+However we want to be open about what else were doing.
+You can see the source of the tester and build your own version as follows if you'd like. 
 
 ### Build the ibpc_tester
 
+If you want to reproduce the tester image run the following command
+
+
+This is packaged and built via a github action to `ghcr.io/opencv/bpc/estimator-tester:latest` however this is how to reproduce it. 
+
 ```bash
 cd ~/ws_bpc/src/bpc
-docker buildx build -t ibpc:tester \
+docker buildx build -t bpc_tester:latest \
     --file ./Dockerfile.tester \
     .
 ```
 
-And then when you invoke `bpc test` append the argument `--tester-image ibpc:tester` to use your local build.
+And then when you invoke `bpc test` append the argument `--tester-image bpc_tester:latest` to use your local build.
 
 ### If you would like the training data
 
-Use the command
+Use the command:
 ```
 bpc fetch ipd_all
 ```
@@ -172,6 +200,9 @@ bpc fetch ipd_all
 
 ### Manually Run components 
 
+It is possible to manually run the components.
+`bpc` shows what it is running on the console output.
+Or you can run as outlined below. 
 
 
 ### Start the Zenoh router
@@ -194,10 +225,3 @@ rocker --nvidia --cuda --network=host ibpc:pose_estimator
 docker run --network=host -e BOP_PATH=/opt/ros/underlay/install/datasets -e SPLIT_TYPE=val -v<PATH_TO_DATASET>:/opt/ros/underlay/install/datasets -v<PATH_TO_OUTPUT_DIR>:/submission -it ibpc:tester
 ```
 
-## Baseline Solution
-
-We provide a simple baseline solution as a reference for implementing the solution in `ibpc_pose_estimator_py`. Please refer to the [baseline_solution](https://github.com/opencv/bpc/tree/baseline_solution) branch and follow the instructions there.
-
-## Next Steps
-
-Stay tuned – more detailed submission instructions and guidelines will be provided soon.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ If you use this tag the `bpc` invocation will be as follows where you use the im
 
 👷 At this point it is up to you to fork and fill in the implementation of the pose estimator. 👷
 
+### Tips
+
+🐌 **If you are iterating a lot of times with the validation and are frustrated by how long the cuda installation is, you can add it to your Dockerfile as below.**
+It will make the image significantly larger, but faster to iterate if you put it higher in the dockerfile. We can't include it in the published image because the image gets too big for hosting and pulling easily.
+
+```
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget software-properties-common gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN \
+  wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb && \
+  dpkg -i cuda-keyring_1.1-1_all.deb && \
+  rm cuda-keyring_1.1-1_all.deb && \
+  \
+  apt-get update && \
+  apt-get -y install cuda-toolkit && \
+  rm -rf /var/lib/apt/lists/*
+```
 
 ### Baseline Solution
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,22 @@ bpc fetch ipd
 
 ## Run the test
 
-**At the moment the published tester is not available. You will have to build it locally see below in Development to build `ibpc:tester` and pass --tester-image `ibpc:tester`
+The test will validate your provide image against the test dataset.
+When you build a new image you rerun this test.
+
+**At the moment the published tester is not available. You will have to build it locally see below in Development to build `ibpc:tester` and pass `--tester-image ibpc:tester` as additional arguments. THe default is `ghcr.io/opencv/bpc/estimator-tester:latest` but that's currently unavailable.
 
 ```
-bpc test  ipd
+bpc test <POSE_ESTIMATOR_DOCKER_TAG> ipd
 ```
+
+For example:
+
+```
+bpc test ghcr.io/opencv/bpc/estimator-example:latest ipd
+```
+**Substitute your own estimator image for ghcr.io/opencv/bpc/estimator-example:latest it's not currently available.**
+If you follow the development build below the argument is `ibpc:pose_estimator`.
 
 The console output will show the system getting started and then the output of the estimator. 
 
@@ -124,7 +135,7 @@ mkdir -p ~/ws_bpc/src
 cd ~/ws_bpc/src
 git clone https://github.com/opencv/bpc.git
 ```
-
+ibpc:pose_estimator
 
 ### Build the ibpc_pose_estimator
 

--- a/ibpc_py/README.md
+++ b/ibpc_py/README.md
@@ -2,28 +2,26 @@
 
 This is the python entrypoint for the Bin Picking Challenge
 
-## Usage
-
-Get a dataset
-`bpc fetch lm`
-
-
-Run tests against a dataset
-`bpc test <Pose Estimator Image Name> <datasetname> `
-
-`bpc test ibpc:pose_estimator lm`
+For example usage see the README at the root of this repository.
 
 
 ## Prerequisites
 
+- [Docker](https://docs.docker.com/)
+ * Docker installed with their user in docker group for passwordless invocations.
+- 7z -- `apt install 7zip`
+- Python3 with virtualenv  -- `apt install python3-virtualenv`
+
 
 ### Install the package:
 
-In a virtualenv
+In a virtualenv:
+
 `pip install ibpc`
 
-Temporary before rocker release of https://github.com/osrf/rocker/pull/317/
-`pip uninstall rocker && pip install git+http://github.com/osrf/rocker.git@console_to_file`
+Or to develop clone this and run: 
+
+`pip install -e .`
 
 
 ### Nvidia Docker (optoinal)


### PR DESCRIPTION
0.0.3 is now on pip

I successfully ran it on my machine with the default implementation. 

I'd love to see this extended with how to run baseline on a published image before merge. 