### PR TITLE
Rely on stable ROS 2 packages

### DIFF
--- a/Dockerfile.estimator
+++ b/Dockerfile.estimator
@@ -57,12 +57,8 @@ FROM base
 ARG SERVICE_PACKAGE=ibpc_pose_estimator_py
 ARG SERVICE_EXECUTABLE_NAME=ibpc_pose_estimator
 
-RUN apt update \
-    && sudo apt install curl -y \
-    && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
 RUN apt-get update \
+    && apt upgrade -y \
     &&  apt install -y ros-jazzy-rmw-zenoh-cpp python3-imageio python3-png python3-pip python3-scipy \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.tester
+++ b/Dockerfile.tester
@@ -41,12 +41,8 @@ RUN . /opt/ros/jazzy/setup.sh \
 # result stage: base + copied install folders from the overlay + service setup.
 FROM base
 
-RUN apt update \
-    && sudo apt install curl -y \
-    && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2-testing/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
 RUN apt-get update \
+    && apt upgrade -y \
     &&  apt install -y ros-jazzy-rmw-zenoh-cpp python3-imageio python3-pandas python3-png python3-pip python3-scipy \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ibpc_py/src/ibpc/ibpc.py
+++ b/ibpc_py/src/ibpc/ibpc.py
@@ -278,7 +278,9 @@ def main():
     args_dict["name"] = ESTIMATOR_CONTAINER
     args_dict["network"] = "host"
     args_dict["extension_blacklist"] = ({},)
-    args_dict["volume"] = [[f"{args_dict['dataset']}/models:/opt/ros/underlay/install/3d_models"], ]
+    args_dict["volume"] = [
+        [f"{args_dict['dataset']}/models:/opt/ros/underlay/install/3d_models"],
+    ]
     if not args_dict["no_gpu"]:
         args_dict["cuda"] = True
         args_dict["nvidia"] = True


### PR DESCRIPTION
Fix #68 

When we started working on `bpc`, `rmw_zenoh_cpp` binaries were not available on mainline (`main`) ROS 2 Jazzy just yet. The package was bloomed and binaries were available in the `ros2-testing` repository. Hence, the docker images relied on a "hack" to update the system's sources list to pull packages from `ros2-testing` instead of `main`. 

Since then, we have stable binaries of `rmw_zenoh_cpp` on `main` but we forgot to remove the hack. This causes the image to continue pulling from `ros2-testing` which is dangerous as there could be several regressions or even deleted packages in [ros2-testing](https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION) which could lead to the system being in an unstable state.

This PR simply deletes the "hack" and adds an `apt upgrade` command to ensure the system has the latest **stable** binaries of ROS 2 Jazzy.